### PR TITLE
feat: enable systemd-resolved

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -70,3 +70,6 @@ for od in $(find * -maxdepth 0 -type d); do
   fi
   popd
 done
+
+# enable systemd-resolved for proper name resolution
+systemctl enable systemd-resolved.service


### PR DESCRIPTION
This PR enables systemd-resolved to have more robust name resolution and to parity coreOS